### PR TITLE
Split storage pages and add icon-based item addition

### DIFF
--- a/congelador.html
+++ b/congelador.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Congelador - Wonder Fridge</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body data-location="Congelador">
+  <nav class="top-menu">
+    <a href="nevera.html">Nevera</a>
+    <a href="congelador.html">Congelador</a>
+    <a href="despensa.html">Despensa</a>
+  </nav>
+  <main>
+    <h1>Congelador</h1>
+    <div id="items"></div>
+    <button id="add-btn" class="add-button">+</button>
+  </main>
+
+  <div id="add-modal" class="modal hidden">
+    <div class="modal-content">
+      <h2>Selecciona un alimento</h2>
+      <div id="icon-grid"></div>
+      <form id="add-form" class="hidden">
+        <div class="selected">
+          <img id="selected-icon" alt="">
+          <span id="selected-name"></span>
+        </div>
+        <input type="number" id="food-qty" min="1" value="1">
+        <select id="food-unit"><option value="unidades">Unidades</option><option value="kilos">Kilos</option><option value="litros">Litros</option></select>
+        <input type="date" id="food-exp">
+        <button type="submit">Agregar</button>
+      </form>
+      <button id="close-modal" type="button">Cerrar</button>
+    </div>
+  </div>
+
+  <script src="icons/icons.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/despensa.html
+++ b/despensa.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Despensa - Wonder Fridge</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body data-location="Despensa">
+  <nav class="top-menu">
+    <a href="nevera.html">Nevera</a>
+    <a href="congelador.html">Congelador</a>
+    <a href="despensa.html">Despensa</a>
+  </nav>
+  <main>
+    <h1>Despensa</h1>
+    <div id="items"></div>
+    <button id="add-btn" class="add-button">+</button>
+  </main>
+
+  <div id="add-modal" class="modal hidden">
+    <div class="modal-content">
+      <h2>Selecciona un alimento</h2>
+      <div id="icon-grid"></div>
+      <form id="add-form" class="hidden">
+        <div class="selected">
+          <img id="selected-icon" alt="">
+          <span id="selected-name"></span>
+        </div>
+        <input type="number" id="food-qty" min="1" value="1">
+        <select id="food-unit"><option value="unidades">Unidades</option><option value="kilos">Kilos</option><option value="litros">Litros</option></select>
+        <input type="date" id="food-exp">
+        <button type="submit">Agregar</button>
+      </form>
+      <button id="close-modal" type="button">Cerrar</button>
+    </div>
+  </div>
+
+  <script src="icons/icons.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/generate-icons.js
+++ b/generate-icons.js
@@ -1,0 +1,17 @@
+const fs = require('fs');
+const path = require('path');
+const iconDir = path.join(__dirname, 'icons');
+const files = fs.readdirSync(iconDir);
+const FRUIT_NAMES = new Set([
+  'aceituna','aguacate','almendra','bayas','cacao','cactus','caf','cereza','coco','dragon_de_fruta','durian','frambuesa','fresa','fruta_estrella','fruta','goji','granada','higo','kiwi','lima','limn','lychee','mango','mangostn','man','manzana','manzana_rosa','maracuy','meln','melocotn','membrillo','naranja','natillas_appel','nuez','pacana','palmera_datilera','papaya','pera','physalis','pia','pltano','sanda','tamarindo','uva'
+]);
+const data = { frutas: [], verduras: [] };
+function displayName(slug){
+  return slug.replace(/_/g,' ').replace(/\b\w/g,c=>c.toUpperCase());
+}
+files.filter(f=>f.endsWith('_icon.png')).forEach(f=>{
+  const slug = f.replace('_icon.png','');
+  const category = FRUIT_NAMES.has(slug) ? 'frutas' : 'verduras';
+  data[category].push({ name: displayName(slug), icon: `icons/${f}` });
+});
+fs.writeFileSync(path.join(iconDir,'icons.js'), `const ICON_CATEGORIES = ${JSON.stringify(data, null, 2)};`);

--- a/icons/icons.js
+++ b/icons/icons.js
@@ -1,0 +1,382 @@
+const ICON_CATEGORIES = {
+  "frutas": [
+    {
+      "name": "Aceituna",
+      "icon": "icons/aceituna_icon.png"
+    },
+    {
+      "name": "Aguacate",
+      "icon": "icons/aguacate_icon.png"
+    },
+    {
+      "name": "Almendra",
+      "icon": "icons/almendra_icon.png"
+    },
+    {
+      "name": "Bayas",
+      "icon": "icons/bayas_icon.png"
+    },
+    {
+      "name": "Cacao",
+      "icon": "icons/cacao_icon.png"
+    },
+    {
+      "name": "Cactus",
+      "icon": "icons/cactus_icon.png"
+    },
+    {
+      "name": "Caf",
+      "icon": "icons/caf_icon.png"
+    },
+    {
+      "name": "Cereza",
+      "icon": "icons/cereza_icon.png"
+    },
+    {
+      "name": "Coco",
+      "icon": "icons/coco_icon.png"
+    },
+    {
+      "name": "Dragon De Fruta",
+      "icon": "icons/dragon_de_fruta_icon.png"
+    },
+    {
+      "name": "Durian",
+      "icon": "icons/durian_icon.png"
+    },
+    {
+      "name": "Frambuesa",
+      "icon": "icons/frambuesa_icon.png"
+    },
+    {
+      "name": "Fresa",
+      "icon": "icons/fresa_icon.png"
+    },
+    {
+      "name": "Fruta Estrella",
+      "icon": "icons/fruta_estrella_icon.png"
+    },
+    {
+      "name": "Fruta",
+      "icon": "icons/fruta_icon.png"
+    },
+    {
+      "name": "Goji",
+      "icon": "icons/goji_icon.png"
+    },
+    {
+      "name": "Granada",
+      "icon": "icons/granada_icon.png"
+    },
+    {
+      "name": "Kiwi",
+      "icon": "icons/kiwi_icon.png"
+    },
+    {
+      "name": "Lima",
+      "icon": "icons/lima_icon.png"
+    },
+    {
+      "name": "Limn",
+      "icon": "icons/limn_icon.png"
+    },
+    {
+      "name": "Lychee",
+      "icon": "icons/lychee_icon.png"
+    },
+    {
+      "name": "Man",
+      "icon": "icons/man_icon.png"
+    },
+    {
+      "name": "Mango",
+      "icon": "icons/mango_icon.png"
+    },
+    {
+      "name": "Mangostn",
+      "icon": "icons/mangostn_icon.png"
+    },
+    {
+      "name": "Manzana",
+      "icon": "icons/manzana_icon.png"
+    },
+    {
+      "name": "Manzana Rosa",
+      "icon": "icons/manzana_rosa_icon.png"
+    },
+    {
+      "name": "Maracuy",
+      "icon": "icons/maracuy_icon.png"
+    },
+    {
+      "name": "Meln",
+      "icon": "icons/meln_icon.png"
+    },
+    {
+      "name": "Melocotn",
+      "icon": "icons/melocotn_icon.png"
+    },
+    {
+      "name": "Membrillo",
+      "icon": "icons/membrillo_icon.png"
+    },
+    {
+      "name": "Naranja",
+      "icon": "icons/naranja_icon.png"
+    },
+    {
+      "name": "Natillas Appel",
+      "icon": "icons/natillas_appel_icon.png"
+    },
+    {
+      "name": "Nuez",
+      "icon": "icons/nuez_icon.png"
+    },
+    {
+      "name": "Pacana",
+      "icon": "icons/pacana_icon.png"
+    },
+    {
+      "name": "Palmera Datilera",
+      "icon": "icons/palmera_datilera_icon.png"
+    },
+    {
+      "name": "Papaya",
+      "icon": "icons/papaya_icon.png"
+    },
+    {
+      "name": "Pera",
+      "icon": "icons/pera_icon.png"
+    },
+    {
+      "name": "Physalis",
+      "icon": "icons/physalis_icon.png"
+    },
+    {
+      "name": "Pia",
+      "icon": "icons/pia_icon.png"
+    },
+    {
+      "name": "Pltano",
+      "icon": "icons/pltano_icon.png"
+    },
+    {
+      "name": "Sanda",
+      "icon": "icons/sanda_icon.png"
+    },
+    {
+      "name": "Tamarindo",
+      "icon": "icons/tamarindo_icon.png"
+    },
+    {
+      "name": "Uva",
+      "icon": "icons/uva_icon.png"
+    }
+  ],
+  "verduras": [
+    {
+      "name": "Acelga",
+      "icon": "icons/acelga_icon.png"
+    },
+    {
+      "name": "Agave",
+      "icon": "icons/agave_icon.png"
+    },
+    {
+      "name": "Aj Picante",
+      "icon": "icons/aj_picante_icon.png"
+    },
+    {
+      "name": "Ajo",
+      "icon": "icons/ajo_icon.png"
+    },
+    {
+      "name": "Albahaca",
+      "icon": "icons/albahaca_icon.png"
+    },
+    {
+      "name": "Alcachofa",
+      "icon": "icons/alcachofa_icon.png"
+    },
+    {
+      "name": "Algodn",
+      "icon": "icons/algodn_icon.png"
+    },
+    {
+      "name": "Aloe Vera",
+      "icon": "icons/aloe_vera_icon.png"
+    },
+    {
+      "name": "Apio",
+      "icon": "icons/apio_icon.png"
+    },
+    {
+      "name": "Bamb",
+      "icon": "icons/bamb_icon.png"
+    },
+    {
+      "name": "Batata",
+      "icon": "icons/batata_icon.png"
+    },
+    {
+      "name": "Berenjenas",
+      "icon": "icons/berenjenas_icon.png"
+    },
+    {
+      "name": "Blanco",
+      "icon": "icons/blanco_icon.png"
+    },
+    {
+      "name": "Brcoli",
+      "icon": "icons/brcoli_icon.png"
+    },
+    {
+      "name": "Caa De Azcar",
+      "icon": "icons/caa_de_azcar_icon.png"
+    },
+    {
+      "name": "Calabacn",
+      "icon": "icons/calabacn_icon.png"
+    },
+    {
+      "name": "Calabaza",
+      "icon": "icons/calabaza_icon.png"
+    },
+    {
+      "name": "Canela",
+      "icon": "icons/canela_icon.png"
+    },
+    {
+      "name": "Caucho",
+      "icon": "icons/caucho_icon.png"
+    },
+    {
+      "name": "Cebolla",
+      "icon": "icons/cebolla_icon.png"
+    },
+    {
+      "name": "Cebolln",
+      "icon": "icons/cebolln_icon.png"
+    },
+    {
+      "name": "Chalote",
+      "icon": "icons/chalote_icon.png"
+    },
+    {
+      "name": "Clavo",
+      "icon": "icons/clavo_icon.png"
+    },
+    {
+      "name": "Col Rizada",
+      "icon": "icons/col_rizada_icon.png"
+    },
+    {
+      "name": "Coliflor",
+      "icon": "icons/coliflor_icon.png"
+    },
+    {
+      "name": "Espinacas",
+      "icon": "icons/espinacas_icon.png"
+    },
+    {
+      "name": "Esprragos",
+      "icon": "icons/esprragos_icon.png"
+    },
+    {
+      "name": "Ficus",
+      "icon": "icons/ficus_icon.png"
+    },
+    {
+      "name": "Frijoles",
+      "icon": "icons/frijoles_icon.png"
+    },
+    {
+      "name": "Girasol",
+      "icon": "icons/girasol_icon.png"
+    },
+    {
+      "name": "Haba De Soja",
+      "icon": "icons/haba_de_soja_icon.png"
+    },
+    {
+      "name": "Hierba",
+      "icon": "icons/hierba_icon.png"
+    },
+    {
+      "name": "Hinojo",
+      "icon": "icons/hinojo_icon.png"
+    },
+    {
+      "name": "Jengibre",
+      "icon": "icons/jengibre_icon.png"
+    },
+    {
+      "name": "Lechuga",
+      "icon": "icons/lechuga_icon.png"
+    },
+    {
+      "name": "Maz",
+      "icon": "icons/maz_icon.png"
+    },
+    {
+      "name": "Nabo",
+      "icon": "icons/nabo_icon.png"
+    },
+    {
+      "name": "Patatas",
+      "icon": "icons/patatas_icon.png"
+    },
+    {
+      "name": "Pepino",
+      "icon": "icons/pepino_icon.png"
+    },
+    {
+      "name": "Pimienta",
+      "icon": "icons/pimienta_icon.png"
+    },
+    {
+      "name": "Puerro",
+      "icon": "icons/puerro_icon.png"
+    },
+    {
+      "name": "Rbano",
+      "icon": "icons/rbano_icon.png"
+    },
+    {
+      "name": "Remolacha",
+      "icon": "icons/remolacha_icon.png"
+    },
+    {
+      "name": "Repollo",
+      "icon": "icons/repollo_icon.png"
+    },
+    {
+      "name": "Repollo Rojo",
+      "icon": "icons/repollo_rojo_icon.png"
+    },
+    {
+      "name": "Seta",
+      "icon": "icons/seta_icon.png"
+    },
+    {
+      "name": "Tomate",
+      "icon": "icons/tomate_icon.png"
+    },
+    {
+      "name": "Trigo",
+      "icon": "icons/trigo_icon.png"
+    },
+    {
+      "name": "Vegetal",
+      "icon": "icons/vegetal_icon.png"
+    },
+    {
+      "name": "Wasabi",
+      "icon": "icons/wasabi_icon.png"
+    },
+    {
+      "name": "Zanahoria",
+      "icon": "icons/zanahoria_icon.png"
+    }
+  ]
+};

--- a/index.html
+++ b/index.html
@@ -3,36 +3,15 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Gestión de Nevera</title>
+  <title>Wonder Fridge</title>
   <link rel="stylesheet" href="styles.css">
 </head>
-<body>
-  <h1>Gestión de Nevera</h1>
-  <section id="add-section">
-    <h2>Agregar alimento</h2>
-    <form id="add-form">
-      <input list="food-list" id="food-name" placeholder="Nombre" required>
-      <datalist id="food-list"></datalist>
-      <input type="number" id="food-quantity" value="1" min="1">
-      <select id="food-location">
-        <option value="Nevera">Nevera</option>
-        <option value="Congelador">Congelador</option>
-        <option value="Despensa">Despensa</option>
-      </select>
-      <input list="groups" id="food-group" placeholder="Categoría">
-      <datalist id="groups"></datalist>
-      <input type="date" id="food-expiration">
-      <button type="submit">Agregar</button>
-    </form>
-  </section>
-  <section id="inventory-section">
-    <h2>Inventario</h2>
-    <div id="inventory"></div>
-  </section>
-  <section id="shopping-section">
-    <h2>Lista de Compras</h2>
-    <ul id="shopping-list"></ul>
-  </section>
-  <script src="script.js"></script>
+<body class="splash">
+  <div class="fridge-icon"></div>
+  <h2>Wonderful, Easy Groceries Organizer</h2>
+  <h1>Wonder Fridge</h1>
+  <script>
+    setTimeout(() => { window.location.href = 'nevera.html'; }, 2000);
+  </script>
 </body>
 </html>

--- a/nevera.html
+++ b/nevera.html
@@ -1,0 +1,42 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Nevera - Wonder Fridge</title>
+  <link rel="stylesheet" href="styles.css">
+</head>
+<body data-location="Nevera">
+  <nav class="top-menu">
+    <a href="nevera.html">Nevera</a>
+    <a href="congelador.html">Congelador</a>
+    <a href="despensa.html">Despensa</a>
+  </nav>
+  <main>
+    <h1>Nevera</h1>
+    <div id="items"></div>
+    <button id="add-btn" class="add-button">+</button>
+  </main>
+
+  <div id="add-modal" class="modal hidden">
+    <div class="modal-content">
+      <h2>Selecciona un alimento</h2>
+      <div id="icon-grid"></div>
+      <form id="add-form" class="hidden">
+        <div class="selected">
+          <img id="selected-icon" alt="">
+          <span id="selected-name"></span>
+        </div>
+        <input type="number" id="food-qty" min="1" value="1">
+        <select id="food-unit"><option value="unidades">Unidades</option><option value="kilos">Kilos</option><option value="litros">Litros</option></select>
+        <input type="date" id="food-exp">
+        <button type="submit">Agregar</button>
+      </form>
+      <button id="close-modal" type="button">Cerrar</button>
+    </div>
+  </div>
+
+  <script src="icons/icons.js"></script>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,143 +1,129 @@
-const FOOD_KEY = 'items';
-const GROUP_KEY = 'groups';
-let items = JSON.parse(localStorage.getItem(FOOD_KEY) || '[]');
-let groups = JSON.parse(localStorage.getItem(GROUP_KEY) || '[]');
+const STORAGE_KEY = 'items';
+let items = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
+let selectedFood = null;
+let editingId = null;
+
+
 
 function save() {
-  localStorage.setItem(FOOD_KEY, JSON.stringify(items));
-  localStorage.setItem(GROUP_KEY, JSON.stringify(groups));
-}
-
-function loadFoodsList() {
-  fetch('foods.json').then(r => r.json()).then(list => {
-    const data = document.getElementById('food-list');
-    list.forEach(name => {
-      const opt = document.createElement('option');
-      opt.value = name;
-      data.appendChild(opt);
-    });
-  });
-}
-
-function loadGroups() {
-  const data = document.getElementById('groups');
-  data.innerHTML = '';
-  groups.forEach(g => {
-    const opt = document.createElement('option');
-    opt.value = g;
-    data.appendChild(opt);
-  });
-}
-
-function expirationClass(date) {
-  if (!date) return '';
-  const diff = (new Date(date) - new Date()) / 86400000;
-  if (diff < 0) return 'expired';
-  if (diff < 3) return 'soon';
-  return '';
-}
-
-function renderInventory() {
-  const container = document.getElementById('inventory');
-  container.innerHTML = '';
-  const locations = ['Nevera', 'Congelador', 'Despensa'];
-  locations.forEach(loc => {
-    const locDiv = document.createElement('div');
-    locDiv.className = 'location';
-    const h3 = document.createElement('h3');
-    h3.textContent = loc;
-    locDiv.appendChild(h3);
-    items.filter(it => it.location === loc).forEach(item => {
-      const div = document.createElement('div');
-      div.className = 'item';
-
-      const nameSpan = document.createElement('span');
-      nameSpan.className = 'name';
-      nameSpan.textContent = item.name;
-      div.appendChild(nameSpan);
-
-      const minus = document.createElement('button');
-      minus.textContent = '-';
-      minus.onclick = () => {
-        if (item.quantity > 1) {
-          item.quantity--;
-          save();
-          render();
-        }
-      };
-      div.appendChild(minus);
-
-      const qty = document.createElement('span');
-      qty.textContent = item.quantity;
-      div.appendChild(qty);
-
-      const plus = document.createElement('button');
-      plus.textContent = '+';
-      plus.onclick = () => {
-        item.quantity++;
-        save();
-        render();
-      };
-      div.appendChild(plus);
-
-      const exp = document.createElement('span');
-      exp.className = 'expiration ' + expirationClass(item.expiration);
-      if (item.expiration) {
-        exp.textContent = new Date(item.expiration).toLocaleDateString();
-      }
-      div.appendChild(exp);
-
-      const shop = document.createElement('input');
-      shop.type = 'checkbox';
-      shop.checked = item.shopping;
-      shop.onchange = () => {
-        item.shopping = shop.checked;
-        save();
-        renderShopping();
-      };
-      div.appendChild(shop);
-
-      locDiv.appendChild(div);
-    });
-    container.appendChild(locDiv);
-  });
-}
-
-function renderShopping() {
-  const ul = document.getElementById('shopping-list');
-  ul.innerHTML = '';
-  items.filter(i => i.shopping).forEach(item => {
-    const li = document.createElement('li');
-    li.textContent = item.name;
-    ul.appendChild(li);
-  });
+  localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
 }
 
 function render() {
-  renderInventory();
-  renderShopping();
+  const container = document.getElementById('items');
+  if (!container) return;
+  container.innerHTML = '';
+  const location = document.body.dataset.location;
+  const byCategory = {};
+  items.filter(i => i.location === location).forEach(item => {
+    (byCategory[item.category] ||= []).push(item);
+  });
+  Object.entries(byCategory).forEach(([cat, list]) => {
+    const title = document.createElement('h2');
+    title.textContent = cat;
+    container.appendChild(title);
+    list.forEach(item => {
+      const div = document.createElement('div');
+      div.className = 'item';
+      const img = document.createElement('img');
+      img.src = item.icon;
+      img.alt = item.name;
+      div.appendChild(img);
+      const name = document.createElement('span');
+      name.textContent = `${item.name} - ${item.quantity} ${item.unit || ''}`;
+      div.appendChild(name);
+      const actions = document.createElement('div');
+      actions.className = 'actions';
+      const editBtn = document.createElement('button');
+      editBtn.textContent = 'Editar';
+      editBtn.onclick = () => openModal(true, item);
+      const delBtn = document.createElement('button');
+      delBtn.textContent = 'Eliminar';
+      delBtn.onclick = () => {
+        items = items.filter(i => i.id !== item.id);
+        save();
+        render();
+      };
+      actions.appendChild(editBtn);
+      actions.appendChild(delBtn);
+      div.appendChild(actions);
+      container.appendChild(div);
+    });
+  });
 }
 
-document.getElementById('add-form').addEventListener('submit', e => {
-  e.preventDefault();
-  const name = document.getElementById('food-name').value.trim();
-  const quantity = parseInt(document.getElementById('food-quantity').value, 10) || 1;
-  const location = document.getElementById('food-location').value;
-  const group = document.getElementById('food-group').value.trim();
-  const expiration = document.getElementById('food-expiration').value;
-  const item = { id: Date.now(), name, quantity, location, group, expiration, shopping: false };
-  items.push(item);
-  if (group && !groups.includes(group)) {
-    groups.push(group);
-    save();
-    loadGroups();
-  } else {
-    save();
+function openModal(edit = false, item = null) {
+  selectedFood = null;
+  editingId = null;
+  const form = document.getElementById('add-form');
+  form.classList.add('hidden');
+  document.getElementById('food-qty').value = '1';
+  document.getElementById('food-unit').value = 'unidades';
+  document.getElementById('food-exp').value = '';
+
+  const grid = document.getElementById('icon-grid');
+  grid.innerHTML = '';
+  Object.entries(ICON_CATEGORIES).forEach(([cat, foods]) => {
+    const header = document.createElement('h3');
+    header.textContent = cat;
+    grid.appendChild(header);
+    const wrap = document.createElement('div');
+    wrap.className = 'category-grid';
+    foods.forEach(food => {
+      const btn = document.createElement('button');
+      btn.type = 'button';
+      btn.className = 'icon-btn';
+      btn.innerHTML = `<img src="${food.icon}" alt="${food.name}"><span>${food.name}</span>`;
+      btn.onclick = () => selectFood({ ...food, category: cat });
+      wrap.appendChild(btn);
+    });
+    grid.appendChild(wrap);
+  });
+
+  if (edit && item) {
+    editingId = item.id;
+    selectFood({ name: item.name, icon: item.icon, category: item.category });
+    document.getElementById('food-qty').value = item.quantity;
+    document.getElementById('food-unit').value = item.unit;
+    document.getElementById('food-exp').value = item.expiration;
   }
-  e.target.reset();
+
+  document.getElementById('add-modal').classList.remove('hidden');
+}
+
+function closeModal() {
+  document.getElementById('add-modal').classList.add('hidden');
+}
+
+function selectFood(food) {
+  selectedFood = food;
+  document.getElementById('selected-icon').src = food.icon;
+  document.getElementById('selected-name').textContent = food.name;
+  document.getElementById('add-form').classList.remove('hidden');
+}
+
+document.getElementById('add-btn')?.addEventListener('click', () => openModal());
+document.getElementById('close-modal')?.addEventListener('click', closeModal);
+
+document.getElementById('add-form')?.addEventListener('submit', e => {
+  e.preventDefault();
+  if (!selectedFood) return;
+  const quantity = parseInt(document.getElementById('food-qty').value, 10) || 1;
+  const unit = document.getElementById('food-unit').value;
+  const expiration = document.getElementById('food-exp').value;
+  const location = document.body.dataset.location;
+  if (editingId) {
+    const idx = items.findIndex(i => i.id === editingId);
+    if (idx > -1) {
+      items[idx] = { ...items[idx], name: selectedFood.name, icon: selectedFood.icon, quantity, unit, expiration, category: selectedFood.category };
+    }
+  } else {
+    const item = { id: Date.now(), name: selectedFood.name, icon: selectedFood.icon, quantity, unit, expiration, location, category: selectedFood.category };
+    items.push(item);
+  }
+  save();
+  closeModal();
   render();
 });
 
-loadFoodsList();
-loadGroups();
 render();

--- a/styles.css
+++ b/styles.css
@@ -1,29 +1,150 @@
 body {
-  font-family: Arial, sans-serif;
-  margin: 1rem;
+  font-family: sans-serif;
+  margin: 0;
 }
-section {
-  margin-bottom: 2rem;
+
+/* Splash screen */
+body.splash {
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  height: 100vh;
+  text-align: center;
+  color: white;
+  background: radial-gradient(circle, #add8e6, #d8b0ff);
 }
+.fridge-icon {
+  width: 80px;
+  height: 120px;
+  background: white;
+  border-radius: 20px;
+  margin-bottom: 1rem;
+  position: relative;
+}
+.fridge-icon::after {
+  content: '';
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  width: 10px;
+  height: 10px;
+  background: white;
+  border-radius: 50%;
+  box-shadow: 0 0 0 2px #ccc;
+}
+
+/* Top menu */
+.top-menu {
+  background: #5E44E0;
+  padding: 0.5rem;
+  display: flex;
+  gap: 1rem;
+}
+.top-menu a {
+  color: white;
+  text-decoration: none;
+}
+
+main {
+  padding: 1rem;
+}
+
+.add-button {
+  position: fixed;
+  bottom: 1rem;
+  right: 1rem;
+  width: 40px;
+  height: 40px;
+  border-radius: 50%;
+  border: none;
+  background: #3B7CF0;
+  color: white;
+  font-size: 24px;
+}
+
+/* Item list */
 .item {
-  border-bottom: 1px solid #ccc;
-  padding: 0.5rem 0;
+  background: white;
+  border-radius: 8px;
+  padding: 0.5rem;
+  margin-bottom: 0.5rem;
   display: flex;
   align-items: center;
   gap: 0.5rem;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.1);
 }
-.item span.name {
-  flex: 1;
+.item img {
+  width: 40px;
+  height: 40px;
 }
-.item span.expiration {
-  font-size: 0.9rem;
+
+/* Modal */
+.modal {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  background: rgba(0,0,0,0.5);
+  display: flex;
+  align-items: center;
+  justify-content: center;
 }
-.expired {
-  color: red;
+.modal.hidden {
+  display: none;
 }
-.soon {
-  color: orange;
+.modal-content {
+  background: white;
+  padding: 1rem;
+  border-radius: 8px;
+  max-width: 90%;
 }
-.location {
-  margin-top: 1rem;
+#icon-grid {
+  max-height: 300px;
+  overflow-y: auto;
+  margin-bottom: 1rem;
+}
+
+.category-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.icon-btn {
+  background: white;
+  border: 1px solid #ccc;
+  border-radius: 8px;
+  padding: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 0.25rem;
+}
+.icon-btn img {
+  width: 40px;
+  height: 40px;
+}
+.selected {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 0.5rem;
+}
+.hidden {
+  display: none;
+}
+
+.actions {
+  margin-left: auto;
+  display: flex;
+  gap: 0.25rem;
+}
+
+.actions button {
+  border: none;
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+  background: #eee;
 }


### PR DESCRIPTION
## Summary
- categorize 94 food icons into frutas and verduras for icon-based selection
- allow editing and deleting stored items with category grouping and unit dropdowns

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68940b2ab7a48324acb374d69c642a23