### PR TITLE
Organize food icons by category and allow editing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,9 @@ Aplicación web simple para organizar los alimentos de la nevera, congelador y d
 - **Alertas de caducidad**: los productos próximos a vencer se muestran en color naranja y los vencidos en rojo.
 - **Lista de compras**: marca los productos que necesitas comprar y consúltalos en un listado independiente.
 - **Agrupación personalizada**: crea categorías propias para organizar los alimentos.
+- **Catálogo visual**: más de 90 iconos agrupados en frutas y verduras para añadir productos con un clic.
+- **Edición y eliminación**: los elementos guardados pueden modificarse o borrarse en cualquier momento.
+- **Unidades estándar**: selecciona entre unidades, kilos o litros al registrar cantidades.
 
 ## Uso
 1. Instala las dependencias:

--- a/congelador.html
+++ b/congelador.html
@@ -21,6 +21,7 @@
   <div id="add-modal" class="modal hidden">
     <div class="modal-content">
       <h2>Selecciona un alimento</h2>
+      <select id="category-select"></select>
       <div id="icon-grid"></div>
       <form id="add-form" class="hidden">
         <div class="selected">
@@ -28,7 +29,11 @@
           <span id="selected-name"></span>
         </div>
         <input type="number" id="food-qty" min="1" value="1">
-        <input type="text" id="food-unit" placeholder="Unidad (ej. unidades, kg, bolsas)">
+        <select id="food-unit">
+          <option value="unidades">Unidades</option>
+          <option value="kg">Kilos</option>
+          <option value="l">Litros</option>
+        </select>
         <input type="date" id="food-exp">
         <button type="submit">Agregar</button>
       </form>

--- a/despensa.html
+++ b/despensa.html
@@ -21,6 +21,7 @@
   <div id="add-modal" class="modal hidden">
     <div class="modal-content">
       <h2>Selecciona un alimento</h2>
+      <select id="category-select"></select>
       <div id="icon-grid"></div>
       <form id="add-form" class="hidden">
         <div class="selected">
@@ -28,7 +29,11 @@
           <span id="selected-name"></span>
         </div>
         <input type="number" id="food-qty" min="1" value="1">
-        <input type="text" id="food-unit" placeholder="Unidad (ej. unidades, kg, bolsas)">
+        <select id="food-unit">
+          <option value="unidades">Unidades</option>
+          <option value="kg">Kilos</option>
+          <option value="l">Litros</option>
+        </select>
         <input type="date" id="food-exp">
         <button type="submit">Agregar</button>
       </form>

--- a/generate-icons.js
+++ b/generate-icons.js
@@ -1,0 +1,27 @@
+const fs = require('fs');
+const path = require('path');
+
+const iconsDir = path.join(__dirname, 'icons');
+const fruits = new Set([
+  'manzana','cereza','aguacate','naranja','limon','lima','platano','banana','sandia','melocoton','durazno','pera','pina','piña','mango','uva','fresa','frambuesa','arandano','coco','kiwi','melon','papaya','granada','pomelo','higo','ciruela','albaricoque'
+]);
+
+function normalize(name) {
+  return name.normalize('NFD').replace(/[^\w]/g,'').toLowerCase();
+}
+
+const files = fs.readdirSync(iconsDir).filter(f => f.endsWith('_icon.png'));
+const categories = { Frutas: [], Verduras: [] };
+
+files.forEach(file => {
+  const base = file.replace('_icon.png','');
+  const norm = normalize(base);
+  const name = base.replace(/_/g, ' ');
+  const cat = fruits.has(norm) ? 'Frutas' : 'Verduras';
+  categories[cat].push({
+    name: name.replace(/\b\w/g, c => c.toUpperCase()),
+    icon: `icons/${file}`
+  });
+});
+
+fs.writeFileSync(path.join(__dirname, 'icons.json'), JSON.stringify(categories, null, 2));

--- a/icons.json
+++ b/icons.json
@@ -1,0 +1,382 @@
+{
+  "Frutas": [
+    {
+      "name": "Aguacate",
+      "icon": "icons/aguacate_icon.png"
+    },
+    {
+      "name": "Cereza",
+      "icon": "icons/cereza_icon.png"
+    },
+    {
+      "name": "Coco",
+      "icon": "icons/coco_icon.png"
+    },
+    {
+      "name": "Frambuesa",
+      "icon": "icons/frambuesa_icon.png"
+    },
+    {
+      "name": "Fresa",
+      "icon": "icons/fresa_icon.png"
+    },
+    {
+      "name": "Granada",
+      "icon": "icons/granada_icon.png"
+    },
+    {
+      "name": "Kiwi",
+      "icon": "icons/kiwi_icon.png"
+    },
+    {
+      "name": "Lima",
+      "icon": "icons/lima_icon.png"
+    },
+    {
+      "name": "Mango",
+      "icon": "icons/mango_icon.png"
+    },
+    {
+      "name": "Manzana",
+      "icon": "icons/manzana_icon.png"
+    },
+    {
+      "name": "Naranja",
+      "icon": "icons/naranja_icon.png"
+    },
+    {
+      "name": "Papaya",
+      "icon": "icons/papaya_icon.png"
+    },
+    {
+      "name": "Pera",
+      "icon": "icons/pera_icon.png"
+    },
+    {
+      "name": "Uva",
+      "icon": "icons/uva_icon.png"
+    }
+  ],
+  "Verduras": [
+    {
+      "name": "Aceituna",
+      "icon": "icons/aceituna_icon.png"
+    },
+    {
+      "name": "Acelga",
+      "icon": "icons/acelga_icon.png"
+    },
+    {
+      "name": "Agave",
+      "icon": "icons/agave_icon.png"
+    },
+    {
+      "name": "Aj Picante",
+      "icon": "icons/aj_picante_icon.png"
+    },
+    {
+      "name": "Ajo",
+      "icon": "icons/ajo_icon.png"
+    },
+    {
+      "name": "Albahaca",
+      "icon": "icons/albahaca_icon.png"
+    },
+    {
+      "name": "Alcachofa",
+      "icon": "icons/alcachofa_icon.png"
+    },
+    {
+      "name": "Algodn",
+      "icon": "icons/algodn_icon.png"
+    },
+    {
+      "name": "Almendra",
+      "icon": "icons/almendra_icon.png"
+    },
+    {
+      "name": "Aloe Vera",
+      "icon": "icons/aloe_vera_icon.png"
+    },
+    {
+      "name": "Apio",
+      "icon": "icons/apio_icon.png"
+    },
+    {
+      "name": "Bamb",
+      "icon": "icons/bamb_icon.png"
+    },
+    {
+      "name": "Batata",
+      "icon": "icons/batata_icon.png"
+    },
+    {
+      "name": "Bayas",
+      "icon": "icons/bayas_icon.png"
+    },
+    {
+      "name": "Berenjenas",
+      "icon": "icons/berenjenas_icon.png"
+    },
+    {
+      "name": "Blanco",
+      "icon": "icons/blanco_icon.png"
+    },
+    {
+      "name": "Brcoli",
+      "icon": "icons/brcoli_icon.png"
+    },
+    {
+      "name": "Caa De Azcar",
+      "icon": "icons/caa_de_azcar_icon.png"
+    },
+    {
+      "name": "Cacao",
+      "icon": "icons/cacao_icon.png"
+    },
+    {
+      "name": "Cactus",
+      "icon": "icons/cactus_icon.png"
+    },
+    {
+      "name": "Caf",
+      "icon": "icons/caf_icon.png"
+    },
+    {
+      "name": "Calabacn",
+      "icon": "icons/calabacn_icon.png"
+    },
+    {
+      "name": "Calabaza",
+      "icon": "icons/calabaza_icon.png"
+    },
+    {
+      "name": "Canela",
+      "icon": "icons/canela_icon.png"
+    },
+    {
+      "name": "Caucho",
+      "icon": "icons/caucho_icon.png"
+    },
+    {
+      "name": "Cebolla",
+      "icon": "icons/cebolla_icon.png"
+    },
+    {
+      "name": "Cebolln",
+      "icon": "icons/cebolln_icon.png"
+    },
+    {
+      "name": "Chalote",
+      "icon": "icons/chalote_icon.png"
+    },
+    {
+      "name": "Clavo",
+      "icon": "icons/clavo_icon.png"
+    },
+    {
+      "name": "Col Rizada",
+      "icon": "icons/col_rizada_icon.png"
+    },
+    {
+      "name": "Coliflor",
+      "icon": "icons/coliflor_icon.png"
+    },
+    {
+      "name": "Dragon De Fruta",
+      "icon": "icons/dragon_de_fruta_icon.png"
+    },
+    {
+      "name": "Durian",
+      "icon": "icons/durian_icon.png"
+    },
+    {
+      "name": "Espinacas",
+      "icon": "icons/espinacas_icon.png"
+    },
+    {
+      "name": "Esprragos",
+      "icon": "icons/esprragos_icon.png"
+    },
+    {
+      "name": "Ficus",
+      "icon": "icons/ficus_icon.png"
+    },
+    {
+      "name": "Frijoles",
+      "icon": "icons/frijoles_icon.png"
+    },
+    {
+      "name": "Fruta Estrella",
+      "icon": "icons/fruta_estrella_icon.png"
+    },
+    {
+      "name": "Fruta",
+      "icon": "icons/fruta_icon.png"
+    },
+    {
+      "name": "Girasol",
+      "icon": "icons/girasol_icon.png"
+    },
+    {
+      "name": "Goji",
+      "icon": "icons/goji_icon.png"
+    },
+    {
+      "name": "Haba De Soja",
+      "icon": "icons/haba_de_soja_icon.png"
+    },
+    {
+      "name": "Hierba",
+      "icon": "icons/hierba_icon.png"
+    },
+    {
+      "name": "Hinojo",
+      "icon": "icons/hinojo_icon.png"
+    },
+    {
+      "name": "Jengibre",
+      "icon": "icons/jengibre_icon.png"
+    },
+    {
+      "name": "Lechuga",
+      "icon": "icons/lechuga_icon.png"
+    },
+    {
+      "name": "Limn",
+      "icon": "icons/limn_icon.png"
+    },
+    {
+      "name": "Lychee",
+      "icon": "icons/lychee_icon.png"
+    },
+    {
+      "name": "Man",
+      "icon": "icons/man_icon.png"
+    },
+    {
+      "name": "Mangostn",
+      "icon": "icons/mangostn_icon.png"
+    },
+    {
+      "name": "Manzana Rosa",
+      "icon": "icons/manzana_rosa_icon.png"
+    },
+    {
+      "name": "Maracuy",
+      "icon": "icons/maracuy_icon.png"
+    },
+    {
+      "name": "Maz",
+      "icon": "icons/maz_icon.png"
+    },
+    {
+      "name": "Meln",
+      "icon": "icons/meln_icon.png"
+    },
+    {
+      "name": "Melocotn",
+      "icon": "icons/melocotn_icon.png"
+    },
+    {
+      "name": "Membrillo",
+      "icon": "icons/membrillo_icon.png"
+    },
+    {
+      "name": "Nabo",
+      "icon": "icons/nabo_icon.png"
+    },
+    {
+      "name": "Natillas Appel",
+      "icon": "icons/natillas_appel_icon.png"
+    },
+    {
+      "name": "Nuez",
+      "icon": "icons/nuez_icon.png"
+    },
+    {
+      "name": "Pacana",
+      "icon": "icons/pacana_icon.png"
+    },
+    {
+      "name": "Palmera Datilera",
+      "icon": "icons/palmera_datilera_icon.png"
+    },
+    {
+      "name": "Patatas",
+      "icon": "icons/patatas_icon.png"
+    },
+    {
+      "name": "Pepino",
+      "icon": "icons/pepino_icon.png"
+    },
+    {
+      "name": "Physalis",
+      "icon": "icons/physalis_icon.png"
+    },
+    {
+      "name": "Pia",
+      "icon": "icons/pia_icon.png"
+    },
+    {
+      "name": "Pimienta",
+      "icon": "icons/pimienta_icon.png"
+    },
+    {
+      "name": "Pltano",
+      "icon": "icons/pltano_icon.png"
+    },
+    {
+      "name": "Puerro",
+      "icon": "icons/puerro_icon.png"
+    },
+    {
+      "name": "Rbano",
+      "icon": "icons/rbano_icon.png"
+    },
+    {
+      "name": "Remolacha",
+      "icon": "icons/remolacha_icon.png"
+    },
+    {
+      "name": "Repollo",
+      "icon": "icons/repollo_icon.png"
+    },
+    {
+      "name": "Repollo Rojo",
+      "icon": "icons/repollo_rojo_icon.png"
+    },
+    {
+      "name": "Sanda",
+      "icon": "icons/sanda_icon.png"
+    },
+    {
+      "name": "Seta",
+      "icon": "icons/seta_icon.png"
+    },
+    {
+      "name": "Tamarindo",
+      "icon": "icons/tamarindo_icon.png"
+    },
+    {
+      "name": "Tomate",
+      "icon": "icons/tomate_icon.png"
+    },
+    {
+      "name": "Trigo",
+      "icon": "icons/trigo_icon.png"
+    },
+    {
+      "name": "Vegetal",
+      "icon": "icons/vegetal_icon.png"
+    },
+    {
+      "name": "Wasabi",
+      "icon": "icons/wasabi_icon.png"
+    },
+    {
+      "name": "Zanahoria",
+      "icon": "icons/zanahoria_icon.png"
+    }
+  ]
+}

--- a/nevera.html
+++ b/nevera.html
@@ -21,6 +21,7 @@
   <div id="add-modal" class="modal hidden">
     <div class="modal-content">
       <h2>Selecciona un alimento</h2>
+      <select id="category-select"></select>
       <div id="icon-grid"></div>
       <form id="add-form" class="hidden">
         <div class="selected">
@@ -28,7 +29,11 @@
           <span id="selected-name"></span>
         </div>
         <input type="number" id="food-qty" min="1" value="1">
-        <input type="text" id="food-unit" placeholder="Unidad (ej. unidades, kg, bolsas)">
+        <select id="food-unit">
+          <option value="unidades">Unidades</option>
+          <option value="kg">Kilos</option>
+          <option value="l">Litros</option>
+        </select>
         <input type="date" id="food-exp">
         <button type="submit">Agregar</button>
       </form>

--- a/script.js
+++ b/script.js
@@ -1,14 +1,8 @@
 const STORAGE_KEY = 'items';
 let items = JSON.parse(localStorage.getItem(STORAGE_KEY) || '[]');
 let selectedFood = null;
-
-const PREDEFINED_FOODS = [
-  { name: 'Manzana', icon: 'icons/manzana_icon.png' },
-  { name: 'Cereza', icon: 'icons/cereza_icon.png' },
-  { name: 'Zanahoria', icon: 'icons/zanahoria_icon.png' },
-  { name: 'Patatas', icon: 'icons/patatas_icon.png' },
-  { name: 'Naranja', icon: 'icons/naranja_icon.png' }
-];
+let editingItemId = null;
+let iconCatalog = {};
 
 function save() {
   localStorage.setItem(STORAGE_KEY, JSON.stringify(items));
@@ -27,29 +21,62 @@ function render() {
     img.alt = item.name;
     div.appendChild(img);
     const name = document.createElement('span');
-    name.textContent = `${item.name} - ${item.quantity} ${item.unit || ''}`;
+    name.textContent = `${item.name} (${item.category}) - ${item.quantity} ${item.unit || ''}`;
     div.appendChild(name);
+    const actions = document.createElement('div');
+    actions.className = 'item-actions';
+    const editBtn = document.createElement('button');
+    editBtn.textContent = 'Editar';
+    editBtn.onclick = () => editItem(item.id);
+    actions.appendChild(editBtn);
+    const delBtn = document.createElement('button');
+    delBtn.textContent = 'Eliminar';
+    delBtn.onclick = () => deleteItem(item.id);
+    actions.appendChild(delBtn);
+    div.appendChild(actions);
     container.appendChild(div);
   });
 }
 
 function openModal() {
+  editingItemId = null;
   selectedFood = null;
   document.getElementById('add-form').classList.add('hidden');
+  document.getElementById('food-qty').value = 1;
+  document.getElementById('food-unit').value = 'unidades';
+  document.getElementById('food-exp').value = '';
+  const categorySelect = document.getElementById('category-select');
   const grid = document.getElementById('icon-grid');
   grid.innerHTML = '';
-  PREDEFINED_FOODS.forEach(food => {
+  categorySelect.innerHTML = '';
+  Object.keys(iconCatalog).forEach(cat => {
+    const opt = document.createElement('option');
+    opt.value = cat;
+    opt.textContent = cat;
+    categorySelect.appendChild(opt);
+  });
+  categorySelect.onchange = () => renderIcons(categorySelect.value);
+  if (categorySelect.options.length > 0) {
+    renderIcons(categorySelect.value);
+  }
+  document.getElementById('add-modal').classList.remove('hidden');
+}
+
+function renderIcons(category) {
+  const grid = document.getElementById('icon-grid');
+  grid.innerHTML = '';
+  (iconCatalog[category] || []).forEach(food => {
     const btn = document.createElement('button');
     btn.type = 'button';
     btn.className = 'icon-btn';
     btn.innerHTML = `<img src="${food.icon}" alt="${food.name}"><span>${food.name}</span>`;
-    btn.onclick = () => selectFood(food);
+    btn.onclick = () => selectFood({ ...food, category });
     grid.appendChild(btn);
   });
-  document.getElementById('add-modal').classList.remove('hidden');
 }
 
 function closeModal() {
+  editingItemId = null;
   document.getElementById('add-modal').classList.add('hidden');
 }
 
@@ -58,6 +85,26 @@ function selectFood(food) {
   document.getElementById('selected-icon').src = food.icon;
   document.getElementById('selected-name').textContent = food.name;
   document.getElementById('add-form').classList.remove('hidden');
+}
+
+function editItem(id) {
+  const item = items.find(i => i.id === id);
+  if (!item) return;
+  editingItemId = id;
+  selectedFood = { name: item.name, icon: item.icon, category: item.category };
+  document.getElementById('selected-icon').src = item.icon;
+  document.getElementById('selected-name').textContent = item.name;
+  document.getElementById('food-qty').value = item.quantity;
+  document.getElementById('food-unit').value = item.unit;
+  document.getElementById('food-exp').value = item.expiration || '';
+  document.getElementById('add-form').classList.remove('hidden');
+  document.getElementById('add-modal').classList.remove('hidden');
+}
+
+function deleteItem(id) {
+  items = items.filter(i => i.id !== id);
+  save();
+  render();
 }
 
 document.getElementById('add-btn')?.addEventListener('click', openModal);
@@ -70,11 +117,24 @@ document.getElementById('add-form')?.addEventListener('submit', e => {
   const unit = document.getElementById('food-unit').value;
   const expiration = document.getElementById('food-exp').value;
   const location = document.body.dataset.location;
-  const item = { id: Date.now(), name: selectedFood.name, icon: selectedFood.icon, quantity, unit, expiration, location };
-  items.push(item);
+  if (editingItemId !== null) {
+    const item = items.find(i => i.id === editingItemId);
+    if (item) {
+      item.quantity = quantity;
+      item.unit = unit;
+      item.expiration = expiration;
+    }
+  } else {
+    const item = { id: Date.now(), name: selectedFood.name, icon: selectedFood.icon, category: selectedFood.category, quantity, unit, expiration, location };
+    items.push(item);
+  }
   save();
   closeModal();
   render();
 });
+
+fetch('icons.json')
+  .then(res => res.json())
+  .then(data => { iconCatalog = data; });
 
 render();

--- a/styles.css
+++ b/styles.css
@@ -79,6 +79,19 @@ main {
   height: 40px;
 }
 
+.item-actions {
+  margin-left: auto;
+  display: flex;
+  gap: 0.25rem;
+}
+
+.item-actions button {
+  border: 1px solid #ccc;
+  background: #f0f0f0;
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+}
+
 /* Modal */
 .modal {
   position: fixed;


### PR DESCRIPTION
## Summary
- Load 90+ food icons from a generated catalog and display them by category
- Add editing and deletion controls for stored items with standard units
- Style item action buttons and update docs

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68940fa010a883248eb75357604334d2