### PR TITLE
Shade items with zero quantity

### DIFF
--- a/congelador.html
+++ b/congelador.html
@@ -43,7 +43,7 @@
             </select>
           </label>
           <label>Cantidad
-            <input type="number" id="detail-qty" min="1" value="1">
+            <input type="number" id="detail-qty" min="0" value="1">
           </label>
           <label>Unidad
             <select id="detail-unit">

--- a/despensa.html
+++ b/despensa.html
@@ -43,7 +43,7 @@
             </select>
           </label>
           <label>Cantidad
-            <input type="number" id="detail-qty" min="1" value="1">
+            <input type="number" id="detail-qty" min="0" value="1">
           </label>
           <label>Unidad
             <select id="detail-unit">

--- a/nevera.html
+++ b/nevera.html
@@ -43,7 +43,7 @@
             </select>
           </label>
           <label>Cantidad
-            <input type="number" id="detail-qty" min="1" value="1">
+            <input type="number" id="detail-qty" min="0" value="1">
           </label>
           <label>Unidad
             <select id="detail-unit">

--- a/script.js
+++ b/script.js
@@ -44,6 +44,9 @@ function render() {
     groups[cat].forEach(item => {
       const div = document.createElement('div');
       div.className = 'item';
+      if (item.quantity <= 0) {
+        div.classList.add('depleted');
+      }
       const img = document.createElement('img');
       img.src = item.icon;
       img.alt = item.name;

--- a/styles.css
+++ b/styles.css
@@ -78,6 +78,9 @@ main {
   gap: 0.5rem;
   box-shadow: 0 1px 2px rgba(0,0,0,0.1);
 }
+.item.depleted {
+  opacity: 0.5;
+}
 .item img {
   width: 40px;
   height: 40px;


### PR DESCRIPTION
## Summary
- fade out list entries when their quantity reaches zero
- permit entering zero quantity across all item forms

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68942125df9883249f6e2151b0dedf75