### PR TITLE
Allow zero item quantity

### DIFF
--- a/script.js
+++ b/script.js
@@ -209,7 +209,8 @@ document.getElementById('modal-item-search')?.addEventListener('input', e => {
 document.getElementById('add-form')?.addEventListener('submit', e => {
   e.preventDefault();
   if (!selectedFood) return;
-  const quantity = parseInt(document.getElementById('detail-qty').value, 10) || 1;
+  let quantity = parseInt(document.getElementById('detail-qty').value, 10);
+  if (isNaN(quantity)) quantity = 1;
   const unit = document.getElementById('detail-unit').value;
   const expiration = document.getElementById('detail-exp').value;
   const location = document.getElementById('detail-location').value;


### PR DESCRIPTION
## Summary
- Permit setting item quantity to 0 instead of auto-changing to 1 by only defaulting to 1 when the quantity input is empty or invalid.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6894228434e883248c96a955f92b2864