### PR TITLE
Integrate shopping list shortcut and streamline item editing

### DIFF
--- a/compras.html
+++ b/compras.html
@@ -29,7 +29,9 @@
         <div id="items-section" class="items-section"></div>
       </div>
       <form id="add-form" class="hidden">
-        <button type="button" id="back-btn">Volver</button>
+        <div class="form-top">
+          <button type="button" id="back-btn">←</button>
+        </div>
         <div class="selected">
           <img id="detail-icon" alt="">
           <div>
@@ -47,9 +49,11 @@
             <option value="l">Litros</option>
           </select>
         </label>
-        <button type="submit">Agregar</button>
+        <div class="form-actions">
+          <button type="submit" id="save-btn">Agregar</button>
+          <button type="button" id="close-modal">Cerrar</button>
+        </div>
       </form>
-      <button id="close-modal" type="button">Cerrar</button>
     </div>
   </div>
 

--- a/congelador.html
+++ b/congelador.html
@@ -28,7 +28,10 @@
           <div id="items-section" class="items-section"></div>
         </div>
         <form id="add-form" class="hidden">
-          <button type="button" id="back-btn">Volver</button>
+          <div class="form-top">
+            <button type="button" id="back-btn">←</button>
+            <button type="button" id="add-shopping-btn">Añadir a lista de compra</button>
+          </div>
           <div class="selected">
             <img id="detail-icon" alt="">
             <div>
@@ -62,9 +65,12 @@
           <label>Nota
             <textarea id="detail-note"></textarea>
           </label>
-          <button type="submit">Agregar</button>
+          <div class="form-actions">
+            <button type="button" id="delete-btn" class="hidden">Eliminar</button>
+            <button type="submit" id="save-btn">Agregar</button>
+            <button type="button" id="close-modal">Cerrar</button>
+          </div>
         </form>
-        <button id="close-modal" type="button">Cerrar</button>
       </div>
     </div>
 

--- a/despensa.html
+++ b/despensa.html
@@ -28,7 +28,10 @@
           <div id="items-section" class="items-section"></div>
         </div>
         <form id="add-form" class="hidden">
-          <button type="button" id="back-btn">Volver</button>
+          <div class="form-top">
+            <button type="button" id="back-btn">←</button>
+            <button type="button" id="add-shopping-btn">Añadir a lista de compra</button>
+          </div>
           <div class="selected">
             <img id="detail-icon" alt="">
             <div>
@@ -62,9 +65,12 @@
           <label>Nota
             <textarea id="detail-note"></textarea>
           </label>
-          <button type="submit">Agregar</button>
+          <div class="form-actions">
+            <button type="button" id="delete-btn" class="hidden">Eliminar</button>
+            <button type="submit" id="save-btn">Agregar</button>
+            <button type="button" id="close-modal">Cerrar</button>
+          </div>
         </form>
-        <button id="close-modal" type="button">Cerrar</button>
       </div>
     </div>
 

--- a/nevera.html
+++ b/nevera.html
@@ -28,7 +28,10 @@
           <div id="items-section" class="items-section"></div>
         </div>
         <form id="add-form" class="hidden">
-          <button type="button" id="back-btn">Volver</button>
+          <div class="form-top">
+            <button type="button" id="back-btn">←</button>
+            <button type="button" id="add-shopping-btn">Añadir a lista de compra</button>
+          </div>
           <div class="selected">
             <img id="detail-icon" alt="">
             <div>
@@ -62,9 +65,12 @@
           <label>Nota
             <textarea id="detail-note"></textarea>
           </label>
-          <button type="submit">Agregar</button>
+          <div class="form-actions">
+            <button type="button" id="delete-btn" class="hidden">Eliminar</button>
+            <button type="submit" id="save-btn">Agregar</button>
+            <button type="button" id="close-modal">Cerrar</button>
+          </div>
         </form>
-        <button id="close-modal" type="button">Cerrar</button>
       </div>
     </div>
 

--- a/styles.css
+++ b/styles.css
@@ -90,6 +90,7 @@ main {
   align-items: center;
   gap: 0.5rem;
   box-shadow: 0 1px 2px rgba(0,0,0,0.1);
+  cursor: pointer;
 }
 .item.depleted {
   opacity: 0.5;
@@ -103,25 +104,6 @@ main {
   height: 40px;
 }
 
-.item-actions {
-  margin-left: auto;
-  display: flex;
-  gap: 0.25rem;
-}
-
-.item-actions button {
-  border: none;
-  background: #5E44E0;
-  color: white;
-  border-radius: 4px;
-  padding: 0.25rem 0.6rem;
-  cursor: pointer;
-  font-size: 0.8rem;
-}
-
-.item-actions button:hover {
-  background: #3B7CF0;
-}
 
 /* Modal */
 .modal {
@@ -152,28 +134,6 @@ main {
   margin-bottom: 0.5rem;
 }
 
-#add-form button[type="submit"] {
-  background: #5E44E0;
-  color: white;
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  cursor: pointer;
-}
-
-#back-btn, #close-modal {
-  background: #ccc;
-  border: none;
-  padding: 0.5rem 1rem;
-  border-radius: 4px;
-  cursor: pointer;
-  margin-top: 0.5rem;
-}
-
-#close-modal {
-  background: #e74c3c;
-  color: white;
-}
 #icon-grid {
   max-height: 300px;
   overflow-y: auto;
@@ -255,11 +215,68 @@ main {
 }
 
 .items-section {
-  display: flex;
-  flex-wrap: wrap;
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
   gap: 0.5rem;
   max-height: 200px;
   overflow-y: auto;
+}
+
+.form-top {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 0.5rem;
+}
+
+.form-actions {
+  display: flex;
+  justify-content: center;
+  gap: 0.5rem;
+  margin-top: 1rem;
+}
+
+#back-btn {
+  background: #ccc;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#add-shopping-btn {
+  background: #5E44E0;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#delete-btn {
+  background: #e74c3c;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#save-btn {
+  background: #5E44E0;
+  color: white;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
+}
+
+#close-modal {
+  background: #ccc;
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 4px;
+  cursor: pointer;
 }
 
 .category-group {


### PR DESCRIPTION
## Summary
- Limit item picker grids to four columns and add consistent modal layouts.
- Replace list item action buttons with click-to-edit and provide in-modal delete and shopping list options.
- Support adding items directly to the shopping list from inventory modals.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895082171588324a9b64b55005c6670