### PR TITLE
Fix multi-select mode not clearing when empty

### DIFF
--- a/script.js
+++ b/script.js
@@ -125,7 +125,11 @@ function toggleSelect(id) {
   } else {
     selectedIds.add(id);
   }
-  updateMultiActions();
+  if (selectedIds.size === 0) {
+    exitMultiSelect();
+  } else {
+    updateMultiActions();
+  }
   render();
 }
 


### PR DESCRIPTION
## Summary
- exit multi-select mode automatically when last selected item is deselected

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6895119f6ed88324b04e64eb5d259f57